### PR TITLE
Server Operations

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,7 @@ gem 'coffee-rails', '~> 4.1.0'
 # Use jquery as the JavaScript library
 gem 'jquery-rails'
 # Turbolinks makes following links in your web application faster. Read more: https://github.com/rails/turbolinks
-gem 'turbolinks'
+gem 'turbolinks', '5.0.0.beta2'
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
 gem 'jbuilder', '~> 2.0'
 # bundle exec rake doc:rails generates the API under doc/api.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -333,8 +333,9 @@ GEM
     thor (0.19.1)
     thread_safe (0.3.5)
     tilt (2.0.2)
-    turbolinks (2.5.3)
-      coffee-rails
+    turbolinks (5.0.0.beta2)
+      turbolinks-source
+    turbolinks-source (5.0.0.beta4)
     turnip (2.1.0)
       gherkin (~> 2.5)
       rspec (>= 3.0, < 4.0)
@@ -408,10 +409,10 @@ DEPENDENCIES
   spring-commands-rspec
   sqlite3
   thin
-  turbolinks
+  turbolinks (= 5.0.0.beta2)
   turnip
   uglifier (>= 1.3.0)
   web-console (~> 2.0)
 
 BUNDLED WITH
-   1.11.2
+   1.12.2

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Don't worry about logging with your API user and key, because Stratos was develo
 * We store your API user and key as a cookie on your browser (vanished when you close your browser)
 * Cookies are signed with rails app key and stored in _encrypted_ form, check this [page](http://api.rubyonrails.org/classes/ActionDispatch/Cookies.html]) for more info on cookies
 * API Key won't be saved on log, as you log, Rails will replace and show `"api_key"=>"[FILTERED]"` on log
+* Disabled logging on Jobs that receive api user / key to process API info on background.
 * We connect to SoftLayer API using HTTPS
 
 ## Roadmap

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -17,21 +17,6 @@
 //= require bootstrap-sprockets
 //= require_tree .
 
-// $(window).scroll(function(e){
-//   var $el = $('#price_box');
-//   var isPositionFixed = ($el.css('position') == 'fixed');
-//   var priceBoxWidth = $el.width();
-//   if ($(this).scrollTop() > 75 && !isPositionFixed){
-//     $('#price_box').css({'position': 'fixed', 'top': '63px' });
-//     $('#price_box').width(priceBoxWidth);
-//   }
-//   if ($(this).scrollTop() < 75 && isPositionFixed)
-//   {
-//     $('#price_box').css({'position': 'static', 'top': '0px'});
-//     $('#price_box').width('100%');
-//   }
-// });
-
 $(document).on('click', '.panel-heading span.clickable', function(e){
     var $this = $(this);
 	if(!$this.hasClass('panel-collapsed')) {
@@ -49,13 +34,7 @@ var initializePaloma = function() {
   Paloma.start();
 }
 
-$(document).on('page:load', function(){
-  if ($('.js-paloma-hook').data('id') != parseInt(Paloma.engine._request.id)) {
-    initializePaloma();
-  }
-});
-
-$(document).ready(function(){
+$(document).on('turbolinks:load', function(){
   initializePaloma();
 });
 
@@ -65,10 +44,24 @@ $(document).on('ajax:send', function(event, xhr){
   var progressType = link.data('loading-progress-type');
   if (message === undefined) { message = "Loading" };
   if (progressType === undefined) { progressType = "success" };
-  console.log(progressType);
   waitingDialog.show(message, { progressType: progressType });
 });
 
 $(document).on('ajax:complete', function(event, xhr, status){
   waitingDialog.hide();
 });
+
+
+document.addEventListener("turbolinks:click", function(event) {
+  var $target = $(event.target);
+  var loading_message = $target.data('loading-message');
+  if (loading_message !== undefined) {
+    var progressType = $target.data('loading-progress-type');
+    if (progressType === undefined) { progressType = "success" };
+    waitingDialog.show(loading_message, { progressType: progressType });
+  }
+})
+
+document.addEventListener("turbolinks:before-cache", function(event) {
+  waitingDialog.hide();
+})

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -58,3 +58,17 @@ $(document).on('page:load', function(){
 $(document).ready(function(){
   initializePaloma();
 });
+
+$(document).on('ajax:send', function(event, xhr){
+  var link = $(event.target);
+  var message = link.data('loading-message');
+  var progressType = link.data('loading-progress-type');
+  if (message === undefined) { message = "Loading" };
+  if (progressType === undefined) { progressType = "success" };
+  console.log(progressType);
+  waitingDialog.show(message, { progressType: progressType });
+});
+
+$(document).on('ajax:complete', function(event, xhr, status){
+  waitingDialog.hide();
+});

--- a/app/assets/javascripts/support/waiting_dialog.js
+++ b/app/assets/javascripts/support/waiting_dialog.js
@@ -1,0 +1,61 @@
+var waitingDialog = waitingDialog || (function ($) {
+    'use strict';
+
+	// Creating modal dialog's DOM
+	var $dialog = $(
+		'<div class="modal fade" data-backdrop="static" data-keyboard="false" tabindex="-1" role="dialog" aria-hidden="true" style="padding-top:15%; overflow-y:visible;">' +
+		'<div class="modal-dialog modal-m">' +
+		'<div class="modal-content">' +
+			'<div class="modal-header"><h3 style="margin:0;"></h3></div>' +
+			'<div class="modal-body">' +
+				'<div class="progress progress-striped active" style="margin-bottom:0;"><div class="progress-bar" style="width: 100%"></div></div>' +
+			'</div>' +
+		'</div></div></div>');
+
+	return {
+		/**
+		 * Opens our dialog
+		 * @param message Custom message
+		 * @param options Custom options:
+		 * 				  options.dialogSize - bootstrap postfix for dialog size, e.g. "sm", "m";
+		 * 				  options.progressType - bootstrap postfix for progress bar type, e.g. "success", "warning".
+		 */
+		show: function (message, options) {
+			// Assigning defaults
+			if (typeof options === 'undefined') {
+				options = {};
+			}
+			if (typeof message === 'undefined') {
+				message = 'Loading';
+			}
+			var settings = $.extend({
+				dialogSize: 'm',
+				progressType: '',
+				onHide: null // This callback runs after the dialog was hidden
+			}, options);
+
+			// Configuring dialog
+			$dialog.find('.modal-dialog').attr('class', 'modal-dialog').addClass('modal-' + settings.dialogSize);
+			$dialog.find('.progress-bar').attr('class', 'progress-bar');
+			if (settings.progressType) {
+				$dialog.find('.progress-bar').addClass('progress-bar-' + settings.progressType);
+			}
+			$dialog.find('h3').text(message);
+			// Adding callbacks
+			if (typeof settings.onHide === 'function') {
+				$dialog.off('hidden.bs.modal').on('hidden.bs.modal', function (e) {
+					settings.onHide.call($dialog);
+				});
+			}
+			// Opening dialog
+			$dialog.modal();
+		},
+		/**
+		 * Closes dialog
+		 */
+		hide: function () {
+			$dialog.modal('hide');
+		}
+	};
+
+})(jQuery);

--- a/app/assets/javascripts/virtual_machines.js
+++ b/app/assets/javascripts/virtual_machines.js
@@ -76,7 +76,6 @@ function scrollToPriceBoxAnchor() {
   $('#price_box .category-name a').click(function(e) {
     e.preventDefault();
     anchorHref = this.getAttribute('href');
-    console.log('going to... ' + anchorHref);
     $('html, body').animate({
       scrollTop: $(anchorHref).offset().top - 90
     }, 200);

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,6 +5,7 @@ class ApplicationController < ActionController::Base
   respond_to :html
   before_action :check_softlayer_login
   before_action :set_current_user
+  rescue_from Softlayer::Errors::SoapError, with: :handle_softlayer_exception
 
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.
@@ -23,5 +24,15 @@ class ApplicationController < ActionController::Base
     if cookies.signed[:api_user].nil? and cookies.signed[:api_key].nil?
       redirect_to login_path
     end
+  end
+
+  def handle_softlayer_exception(exception)
+    return exception_invalid_login if exception.message.match /Invalid API token./
+  end
+
+  def exception_invalid_login
+    cookies.signed[:api_user] = nil
+    cookies.signed[:api_key] = nil
+    redirect_to login_path, alert: "API returned 'Invalid Credentials', Please Login Again"
   end
 end

--- a/app/controllers/login_controller.rb
+++ b/app/controllers/login_controller.rb
@@ -15,6 +15,8 @@ class LoginController < ApplicationController
       if connection.valid?
         cookies.signed[:api_user] = api_user
         cookies.signed[:api_key] = api_key
+        WarmCacheJob.logger = nil
+        WarmCacheJob.perform_later(api_user, api_key)
         redirect_to root_path, notice: "Logged In Successfully"
       else
         redirect_to login_path, alert: "Invalid Credentials"

--- a/app/controllers/virtual_machines_controller.rb
+++ b/app/controllers/virtual_machines_controller.rb
@@ -36,4 +36,38 @@ class VirtualMachinesController < ApplicationController
       format.js { render action: "price_box" }
     end
   end
+
+  def reboot
+    vm = VirtualMachine.find(params[:id])
+    vm.reboot
+
+    respond_to do |format|
+      format.js { render }
+    end
+  end
+
+  def power_cycle
+    vm = VirtualMachine.find(params[:id])
+
+    if vm.running?
+      vm.power_off
+      @notice = "Machine turned off"
+    elsif
+      vm.power_on
+      @notice = "Machine turned on"
+    end
+
+    respond_to do |format|
+      format.js { render }
+    end
+  end
+
+  def destroy
+    vm = VirtualMachine.find(params[:id])
+    vm.destroy
+
+    respond_to do |format|
+      format.js { render }
+    end
+  end
 end

--- a/app/jobs/warm_cache_job.rb
+++ b/app/jobs/warm_cache_job.rb
@@ -1,0 +1,13 @@
+class WarmCacheJob < ActiveJob::Base
+  queue_as :default
+
+  def perform(api_user, api_key)
+    SoftlayerConnection.new(api_user, api_key)
+    WarmDatacentersCacheJob.perform_later(api_user, api_key)
+    WarmCreateOptionsCacheJob.perform_later(api_user, api_key)
+    WarmPackageCacheJob.perform_later(api_user, api_key)
+    WarmConfigurationCacheJob.perform_later(api_user, api_key)
+    WarmProductCategoriesCacheJob.perform_later(api_user, api_key)
+    WarmStoreHashCacheJob.perform_later(api_user, api_key)
+  end
+end

--- a/app/jobs/warm_configuration_cache_job.rb
+++ b/app/jobs/warm_configuration_cache_job.rb
@@ -1,0 +1,9 @@
+class WarmConfigurationCacheJob < WarmCacheJob
+  queue_as :default
+
+  def perform(api_user, api_key)
+    SoftlayerConnection.new(api_user, api_key)
+    vm = VirtualMachine.new
+    vm.send(:configuration)
+  end
+end

--- a/app/jobs/warm_create_options_cache_job.rb
+++ b/app/jobs/warm_create_options_cache_job.rb
@@ -1,0 +1,9 @@
+class WarmCreateOptionsCacheJob < WarmCacheJob
+  queue_as :default
+
+  def perform(api_user, api_key)
+    SoftlayerConnection.new(api_user, api_key)
+    vm = VirtualMachine.new
+    vm.send(:create_options)
+  end
+end

--- a/app/jobs/warm_datacenters_cache_job.rb
+++ b/app/jobs/warm_datacenters_cache_job.rb
@@ -1,0 +1,9 @@
+class WarmDatacentersCacheJob < WarmCacheJob
+  queue_as :default
+
+  def perform(api_user, api_key)
+    SoftlayerConnection.new(api_user, api_key)
+    vm = VirtualMachine.new
+    vm.send(:datacenters)
+  end
+end

--- a/app/jobs/warm_package_cache_job.rb
+++ b/app/jobs/warm_package_cache_job.rb
@@ -1,0 +1,9 @@
+class WarmPackageCacheJob < WarmCacheJob
+  queue_as :default
+
+  def perform(api_user, api_key)
+    SoftlayerConnection.new(api_user, api_key)
+    vm = VirtualMachine.new
+    vm.send(:package)
+  end
+end

--- a/app/jobs/warm_product_categories_cache_job.rb
+++ b/app/jobs/warm_product_categories_cache_job.rb
@@ -1,0 +1,9 @@
+class WarmProductCategoriesCacheJob < WarmCacheJob
+  queue_as :default
+
+  def perform(api_user, api_key)
+    SoftlayerConnection.new(api_user, api_key)
+    vm = VirtualMachine.new
+    vm.send(:product_categories)
+  end
+end

--- a/app/jobs/warm_store_hash_cache_job.rb
+++ b/app/jobs/warm_store_hash_cache_job.rb
@@ -1,0 +1,8 @@
+class WarmStoreHashCacheJob < WarmCacheJob
+  queue_as :default
+
+  def perform(api_user, api_key)
+    SoftlayerConnection.new(api_user, api_key)
+    StoreHash.generate_hash
+  end
+end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -21,7 +21,8 @@
       <%= render partial: 'navbar' %>
       <%= flash_messages %>
       <%= yield %>
-      <%= insert_paloma_hook %>
     </div>
+    <%= insert_paloma_hook %>
+    
   </body>
 </html>

--- a/app/views/login/new.html.erb
+++ b/app/views/login/new.html.erb
@@ -11,9 +11,11 @@
               <%= f.input :api_user, placeholder: 'Your SoftLayer API User', autofocus: true %>
               <%= f.input :api_key, as: :password, placeholder: 'Your SoftLayer API Key' %>
               <!-- Change this to a button or input when using this as a form -->
-              <%= f.button :submit, class: 'btn-success', value: 'Login' %>
+              <center><%= f.button :submit, class: 'btn-success btn-block', value: 'Login' %></center>
             </fieldset>
           <% end %>
+          <br />
+          <div class="alert alert-warning" role="alert"><strong>Attention!</strong> First time you login, Stratos will process some information from SoftLayer API (<b>no</b> sensitive data!) and store as cache, so don't worry if your login take a little while.</div>
         </div>
       </div>
     </div>

--- a/app/views/virtual_machines/_vm.html.erb
+++ b/app/views/virtual_machines/_vm.html.erb
@@ -5,18 +5,20 @@
   <td><%= vm.provision_date.nil? ? '-' : vm.provision_date.to_date %></td>
   <td>
     <ul class="actions">
+      <% if vm.active? %>
       <li class="dropdown">
         <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Actions <span class="caret"></span></a>
         <ul class="dropdown-menu">
-          <li><a href="#">Reboot</a></li>
-          <li><a href="#">Power On/Off</a></li>
+          <li><%= link_to "Reboot", reboot_virtual_machine_path(vm.id), remote: true, data: { loading_message: 'Rebooting Server' } %></li>
+          <li><%= link_to "Power On/Off", power_cycle_virtual_machine_path(vm.id), remote: true, data: { loading_message: 'Power Cycling Server' } %></li>
           <li><a href="#">Rename Instance</a></li>
           <li><a href="#">View Audit Logs</a></li>
           <li><a href="#">Upgrade / Downgrade</a></li>
           <li role="separator" class="divider"></li>
-          <li><a href="#">Cancel Device</a></li>
+          <li><%= link_to "Cancel Device", virtual_machine_path(vm.id), remote: true, method: :delete, data: { loading_message: 'Destroying Server' } %></li>
         </ul>
       </li>
+      <% end %>
     </ul>
   </td>
 </tr>

--- a/app/views/virtual_machines/destroy.js.erb
+++ b/app/views/virtual_machines/destroy.js.erb
@@ -1,0 +1,2 @@
+$('li.dropdown.open').removeClass('open');
+$('.container nav.navbar').after('<div class="alert alert-success alert-dismissible" role="alert"><button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>Machine has been destroyed</div>');

--- a/app/views/virtual_machines/index.html.erb
+++ b/app/views/virtual_machines/index.html.erb
@@ -17,4 +17,4 @@ Virtual Machines
   </tbody>
 </table>
 
-<%= link_to "New Virtual Machine", new_virtual_machine_path, class: "btn btn-success", role: 'button' %>
+<%= link_to "New Virtual Machine", new_virtual_machine_path, class: "btn btn-success", role: 'button', data: { loading_message: 'Loading Virtual Machine Options..' } %>

--- a/app/views/virtual_machines/power_cycle.js.erb
+++ b/app/views/virtual_machines/power_cycle.js.erb
@@ -1,0 +1,2 @@
+$('li.dropdown.open').removeClass('open');
+$('.container nav.navbar').after('<div class="alert alert-success alert-dismissible" role="alert"><button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button><%= @notice %></div>');

--- a/app/views/virtual_machines/reboot.js.erb
+++ b/app/views/virtual_machines/reboot.js.erb
@@ -1,0 +1,2 @@
+$('li.dropdown.open').removeClass('open');
+$('.container nav.navbar').after('<div class="alert alert-success alert-dismissible" role="alert"><button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>Machine has been rebooted</div>');

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,10 @@ Rails.application.routes.draw do
     collection do
       post :price_box
     end
+    member do
+      get :reboot
+      get :power_cycle
+    end
   end
   root to: 'virtual_machines#index'
 end


### PR DESCRIPTION
The rational on this PR is provide a similar interface to control.softlayer.com that enable the same basic operations ( reboot / power cycle / cancel device ).

Views are not so beautiful, but the idea is keep it using twitter bootstrap and be as simple as possible to make easier to understand and see how it works.

**TODO**
- Rename instance
- View audit logs

Some screenshots...
## Operations Menu

<img width="1276" alt="server_operations_pr" src="https://cloud.githubusercontent.com/assets/517743/15120527/89099df4-15ec-11e6-9944-9f95c2980ad2.png">
## Background Job (Ajax Request) Modal

<img width="1281" alt="server_operations_pr2" src="https://cloud.githubusercontent.com/assets/517743/15120642/06195280-15ed-11e6-8a8d-dfc93175ab93.png">
## Operation Confirmation

<img width="1280" alt="server_operations_pr3" src="https://cloud.githubusercontent.com/assets/517743/15120648/0eade118-15ed-11e6-8821-927040ce90e0.png">
