### PR TITLE
Error in your README.md markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ If you'd like to test in a production environment, it's normal rails deployment,
 Don't worry about logging with your API user and key, because Stratos was develop to avoid data leakage, so we assume some premisses:
 
 * We store your API user and key as a cookie on your browser (vanished when you close your browser)
-* Cookies are signed with rails app key and stored in _encrypted_ form, check this [page](http://api.rubyonrails.org/classes/ActionDispatch/Cookies.html]) for more info on cookies
+* Cookies are signed with rails app key and stored in _encrypted_ form, check this [page](http://api.rubyonrails.org/classes/ActionDispatch/Cookies.html) for more info on cookies
 * API Key won't be saved on log, as you log, Rails will replace and show `"api_key"=>"[FILTERED]"` on log
 * Disabled logging on Jobs that receive api user / key to process API info on background.
 * We connect to SoftLayer API using HTTPS


### PR DESCRIPTION
Currently, it adds an extra `]` which turns out to fail pretty badly on the rubyonrails server (bad sanitation of URl data apparently):

```
404 Not Found
nginx/1.14.0 (Ubuntu)
```